### PR TITLE
Add mobile touch controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,13 +82,10 @@
       75% { transform: rotate(15deg); }
     }
 
-    /* Show rotate overlay on mobile portrait */
+    /* Show rotate overlay on mobile portrait - overlay on top, don't hide game */
     @media screen and (max-width: 900px) and (orientation: portrait) {
       #rotate-overlay {
         display: flex;
-      }
-      #game-container {
-        display: none;
       }
     }
   </style>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="mobile-web-app-capable" content="yes">
+  <meta name="screen-orientation" content="landscape">
   <title>Masqacre - A Masquerade Mystery</title>
   <style>
     * {
@@ -18,41 +19,88 @@
       height: 100%;
       overflow: hidden;
       background-color: #1a1a2e;
-      /* Prevent pull-to-refresh and overscroll */
       overscroll-behavior: none;
       -webkit-overflow-scrolling: touch;
-      /* iOS safe area support */
-      padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
     }
     body {
       display: flex;
       justify-content: center;
       align-items: center;
-      /* Use dvh for mobile browsers (dynamic viewport height) */
       min-height: 100vh;
       min-height: 100dvh;
-      /* Prevent text selection */
       -webkit-user-select: none;
       user-select: none;
-      /* Prevent touch callout */
       -webkit-touch-callout: none;
     }
     #game-container {
       image-rendering: pixelated;
       image-rendering: crisp-edges;
-      /* Prevent canvas from being larger than viewport */
       max-width: 100%;
       max-height: 100%;
-      /* Touch action for game */
       touch-action: none;
     }
     #game-container canvas {
       display: block;
       touch-action: none;
     }
+
+    /* Rotate device overlay - shown in portrait on mobile */
+    #rotate-overlay {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background-color: #1a1a2e;
+      z-index: 9999;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      color: #ffd700;
+      font-family: Georgia, serif;
+      text-align: center;
+      padding: 20px;
+    }
+    #rotate-overlay .rotate-icon {
+      font-size: 80px;
+      margin-bottom: 20px;
+      animation: rotate-hint 2s ease-in-out infinite;
+    }
+    #rotate-overlay h2 {
+      font-size: 28px;
+      margin-bottom: 15px;
+    }
+    #rotate-overlay p {
+      font-size: 18px;
+      color: #aaa;
+      max-width: 300px;
+    }
+    @keyframes rotate-hint {
+      0%, 100% { transform: rotate(0deg); }
+      25% { transform: rotate(-15deg); }
+      75% { transform: rotate(15deg); }
+    }
+
+    /* Show rotate overlay on mobile portrait */
+    @media screen and (max-width: 900px) and (orientation: portrait) {
+      #rotate-overlay {
+        display: flex;
+      }
+      #game-container {
+        display: none;
+      }
+    }
   </style>
 </head>
 <body>
+  <!-- Rotate device prompt for portrait mode -->
+  <div id="rotate-overlay">
+    <div class="rotate-icon">📱</div>
+    <h2>Rotate Your Device</h2>
+    <p>Masqacre plays best in landscape mode. Please rotate your device to continue.</p>
+  </div>
+
   <div id="game-container"></div>
   <script type="module" src="/src/main.ts"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="mobile-web-app-capable" content="yes">
   <title>Masqacre - A Masquerade Mystery</title>
   <style>
     * {
@@ -10,17 +13,42 @@
       padding: 0;
       box-sizing: border-box;
     }
-    body {
+    html, body {
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
       background-color: #1a1a2e;
+      /* Prevent pull-to-refresh and overscroll */
+      overscroll-behavior: none;
+      -webkit-overflow-scrolling: touch;
+      /* iOS safe area support */
+      padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+    }
+    body {
       display: flex;
       justify-content: center;
       align-items: center;
+      /* Use dvh for mobile browsers (dynamic viewport height) */
       min-height: 100vh;
-      overflow: hidden;
+      min-height: 100dvh;
+      /* Prevent text selection */
+      -webkit-user-select: none;
+      user-select: none;
+      /* Prevent touch callout */
+      -webkit-touch-callout: none;
     }
     #game-container {
       image-rendering: pixelated;
       image-rendering: crisp-edges;
+      /* Prevent canvas from being larger than viewport */
+      max-width: 100%;
+      max-height: 100%;
+      /* Touch action for game */
+      touch-action: none;
+    }
+    #game-container canvas {
+      display: block;
+      touch-action: none;
     }
   </style>
 </head>

--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -41,11 +41,25 @@ export const GameConfig: Phaser.Types.Core.GameConfig = {
   scene: [BootScene, MenuScene, GameScene, UIScene, DialogueScene, GameOverScene],
   scale: {
     mode: Phaser.Scale.FIT,
-    autoCenter: Phaser.Scale.CENTER_BOTH
+    autoCenter: Phaser.Scale.CENTER_BOTH,
+    // Expand to fill available space while maintaining aspect ratio
+    expandParent: true,
+    // Fullscreen settings for mobile
+    fullscreenTarget: 'game-container'
   },
   render: {
     antialias: false,
     pixelArt: true,
     roundPixels: true
+  },
+  input: {
+    // Enable touch input
+    touch: true,
+    // Prevent right-click context menu
+    mouse: {
+      preventDefaultDown: true,
+      preventDefaultUp: true,
+      preventDefaultMove: true
+    }
   }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,4 +9,26 @@ window.addEventListener('resize', () => {
   game.scale.refresh();
 });
 
+// Handle orientation change (iOS needs this separately)
+window.addEventListener('orientationchange', () => {
+  // iOS needs a delay for the viewport to update after orientation change
+  setTimeout(() => {
+    game.scale.refresh();
+  }, 100);
+
+  // Additional delayed refresh for stubborn cases
+  setTimeout(() => {
+    game.scale.refresh();
+  }, 300);
+});
+
+// Handle visibility change (when switching apps on mobile)
+document.addEventListener('visibilitychange', () => {
+  if (!document.hidden) {
+    setTimeout(() => {
+      game.scale.refresh();
+    }, 100);
+  }
+});
+
 export default game;

--- a/src/scenes/DialogueScene.ts
+++ b/src/scenes/DialogueScene.ts
@@ -160,7 +160,7 @@ export class DialogueScene extends Phaser.Scene {
     const mobile = isMobile();
     const fontSize = mobile ? '16px' : '12px';
     const lineHeight = mobile ? 32 : 22;
-    const startY = mobile ? 5 : -5;
+    const startY = mobile ? -27 : -5;
 
     choices.forEach((choice, index) => {
       // Create a background for better tap target on mobile

--- a/src/scenes/DialogueScene.ts
+++ b/src/scenes/DialogueScene.ts
@@ -172,12 +172,17 @@ export class DialogueScene extends Phaser.Scene {
   }
 
   private displayContinuePrompt(nextNodeId: string): void {
-    const text = this.add.text(0, 70, '[SPACE or ENTER to continue]', {
+    const isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+    const promptText = isMobile ? '[Tap to continue]' : '[SPACE or ENTER to continue]';
+
+    const text = this.add.text(0, 70, promptText, {
       fontFamily: 'monospace',
       fontSize: '12px',
       color: '#888888'
     });
     text.setOrigin(0.5);
+    text.setInteractive({ useHandCursor: true });
+    text.on('pointerdown', () => this.confirmSelection());
     this.dialogueBox.add(text);
     this.choiceTexts.push(text);
 
@@ -186,12 +191,17 @@ export class DialogueScene extends Phaser.Scene {
   }
 
   private displayExitPrompt(): void {
-    const text = this.add.text(0, 70, '[SPACE or ENTER to leave]', {
+    const isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+    const promptText = isMobile ? '[Tap to leave]' : '[SPACE or ENTER to leave]';
+
+    const text = this.add.text(0, 70, promptText, {
       fontFamily: 'monospace',
       fontSize: '12px',
       color: '#888888'
     });
     text.setOrigin(0.5);
+    text.setInteractive({ useHandCursor: true });
+    text.on('pointerdown', () => this.confirmSelection());
     this.dialogueBox.add(text);
     this.choiceTexts.push(text);
 

--- a/src/scenes/DialogueScene.ts
+++ b/src/scenes/DialogueScene.ts
@@ -159,7 +159,7 @@ export class DialogueScene extends Phaser.Scene {
   private displayChoices(choices: DialogueChoice[]): void {
     const mobile = isMobile();
     const fontSize = mobile ? '16px' : '12px';
-    const lineHeight = mobile ? 32 : 22;
+    const lineHeight = mobile ? 26 : 22;
     const startY = mobile ? -27 : -5;
 
     choices.forEach((choice, index) => {

--- a/src/scenes/DialogueScene.ts
+++ b/src/scenes/DialogueScene.ts
@@ -5,6 +5,11 @@ import { DialogueNode, DialogueChoice } from '../types';
 import { GAME_WIDTH, GAME_HEIGHT } from '../config/GameConfig';
 import { getDialogueForNPC } from '../data/DialogueData';
 
+// Helper to detect mobile for larger fonts
+const isMobile = (): boolean => {
+  return 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+};
+
 export class DialogueScene extends Phaser.Scene {
   private gameScene!: GameScene;
   private npc!: NPC;
@@ -72,6 +77,11 @@ export class DialogueScene extends Phaser.Scene {
   private createDialogueBox(): void {
     this.dialogueBox = this.add.container(GAME_WIDTH / 2, GAME_HEIGHT - 120);
 
+    // Mobile-friendly font sizes
+    const mobile = isMobile();
+    const speakerFontSize = mobile ? '20px' : '16px';
+    const dialogueFontSize = mobile ? '16px' : '13px';
+
     // Box background - taller to fit all content
     const bg = this.add.graphics();
     bg.fillStyle(0x1a1a2e, 0.95);
@@ -107,18 +117,18 @@ export class DialogueScene extends Phaser.Scene {
     // Speaker name
     this.speakerText = this.add.text(this.textStartX, -100, '', {
       fontFamily: 'Georgia, serif',
-      fontSize: '16px',
+      fontSize: speakerFontSize,
       color: '#ffd700'
     });
     this.dialogueBox.add(this.speakerText);
 
     // Dialogue text
-    this.dialogueText = this.add.text(this.textStartX, -75, '', {
+    this.dialogueText = this.add.text(this.textStartX, -70, '', {
       fontFamily: 'monospace',
-      fontSize: '13px',
+      fontSize: dialogueFontSize,
       color: '#ffffff',
       wordWrap: { width: 620 },
-      lineSpacing: 2
+      lineSpacing: mobile ? 6 : 2
     });
     this.dialogueBox.add(this.dialogueText);
   }
@@ -147,13 +157,26 @@ export class DialogueScene extends Phaser.Scene {
   }
 
   private displayChoices(choices: DialogueChoice[]): void {
-    const startY = -5;
+    const mobile = isMobile();
+    const fontSize = mobile ? '16px' : '12px';
+    const lineHeight = mobile ? 32 : 22;
+    const startY = mobile ? 5 : -5;
 
     choices.forEach((choice, index) => {
-      const text = this.add.text(this.textStartX, startY + index * 22, `${index + 1}. ${choice.text}`, {
+      // Create a background for better tap target on mobile
+      if (mobile) {
+        const bg = this.add.graphics();
+        bg.fillStyle(0x333344, 0.5);
+        bg.fillRoundedRect(this.textStartX - 5, startY + index * lineHeight - 4, 640, lineHeight - 4, 4);
+        this.dialogueBox.add(bg);
+        this.choiceTexts.push(bg as unknown as Phaser.GameObjects.Text);
+      }
+
+      const text = this.add.text(this.textStartX, startY + index * lineHeight, `${index + 1}. ${choice.text}`, {
         fontFamily: 'monospace',
-        fontSize: '12px',
-        color: index === this.selectedChoice ? '#ffd700' : '#aaaaaa'
+        fontSize: fontSize,
+        color: index === this.selectedChoice ? '#ffd700' : '#aaaaaa',
+        padding: mobile ? { x: 5, y: 5 } : undefined
       });
       text.setInteractive({ useHandCursor: true });
 
@@ -172,13 +195,26 @@ export class DialogueScene extends Phaser.Scene {
   }
 
   private displayContinuePrompt(nextNodeId: string): void {
-    const isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-    const promptText = isMobile ? '[Tap to continue]' : '[SPACE or ENTER to continue]';
+    const mobile = isMobile();
+    const promptText = mobile ? '[ TAP TO CONTINUE ]' : '[SPACE or ENTER to continue]';
+    const fontSize = mobile ? '18px' : '12px';
 
-    const text = this.add.text(0, 70, promptText, {
+    // Add a visible button background on mobile
+    if (mobile) {
+      const bg = this.add.graphics();
+      bg.fillStyle(0x8b0000, 0.8);
+      bg.fillRoundedRect(-120, 55, 240, 40, 8);
+      bg.lineStyle(2, 0xffd700);
+      bg.strokeRoundedRect(-120, 55, 240, 40, 8);
+      this.dialogueBox.add(bg);
+      this.choiceTexts.push(bg as unknown as Phaser.GameObjects.Text);
+    }
+
+    const text = this.add.text(0, mobile ? 75 : 70, promptText, {
       fontFamily: 'monospace',
-      fontSize: '12px',
-      color: '#888888'
+      fontSize: fontSize,
+      color: mobile ? '#ffd700' : '#888888',
+      fontStyle: mobile ? 'bold' : 'normal'
     });
     text.setOrigin(0.5);
     text.setInteractive({ useHandCursor: true });
@@ -191,13 +227,26 @@ export class DialogueScene extends Phaser.Scene {
   }
 
   private displayExitPrompt(): void {
-    const isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-    const promptText = isMobile ? '[Tap to leave]' : '[SPACE or ENTER to leave]';
+    const mobile = isMobile();
+    const promptText = mobile ? '[ TAP TO LEAVE ]' : '[SPACE or ENTER to leave]';
+    const fontSize = mobile ? '18px' : '12px';
 
-    const text = this.add.text(0, 70, promptText, {
+    // Add a visible button background on mobile
+    if (mobile) {
+      const bg = this.add.graphics();
+      bg.fillStyle(0x8b0000, 0.8);
+      bg.fillRoundedRect(-100, 55, 200, 40, 8);
+      bg.lineStyle(2, 0xffd700);
+      bg.strokeRoundedRect(-100, 55, 200, 40, 8);
+      this.dialogueBox.add(bg);
+      this.choiceTexts.push(bg as unknown as Phaser.GameObjects.Text);
+    }
+
+    const text = this.add.text(0, mobile ? 75 : 70, promptText, {
       fontFamily: 'monospace',
-      fontSize: '12px',
-      color: '#888888'
+      fontSize: fontSize,
+      color: mobile ? '#ffd700' : '#888888',
+      fontStyle: mobile ? 'bold' : 'normal'
     });
     text.setOrigin(0.5);
     text.setInteractive({ useHandCursor: true });

--- a/src/scenes/UIScene.ts
+++ b/src/scenes/UIScene.ts
@@ -628,6 +628,8 @@ export class UIScene extends Phaser.Scene {
   }
 
   private onClueDiscovered(clue: ClueType): void {
+    const mobile = isTouchDevice();
+
     // Create modal overlay
     const overlay = this.add.graphics();
     overlay.fillStyle(0x000000, 0.7);
@@ -638,18 +640,20 @@ export class UIScene extends Phaser.Scene {
     const modal = this.add.container(GAME_WIDTH / 2, GAME_HEIGHT / 2);
     modal.setDepth(201);
 
-    // Modal background
+    // Modal background - larger on mobile
+    const modalWidth = mobile ? 420 : 360;
+    const modalHeight = mobile ? 200 : 160;
     const bg = this.add.graphics();
     bg.fillStyle(0x1a1a2e, 0.98);
-    bg.fillRect(-180, -80, 360, 160);
+    bg.fillRect(-modalWidth/2, -modalHeight/2, modalWidth, modalHeight);
     bg.lineStyle(3, 0xffd700);
-    bg.strokeRect(-180, -80, 360, 160);
+    bg.strokeRect(-modalWidth/2, -modalHeight/2, modalWidth, modalHeight);
     modal.add(bg);
 
     // Header
-    const header = this.add.text(0, -55, 'CLUE DISCOVERED', {
+    const header = this.add.text(0, -modalHeight/2 + 25, 'CLUE DISCOVERED', {
       fontFamily: 'Georgia, serif',
-      fontSize: '20px',
+      fontSize: mobile ? '26px' : '20px',
       color: '#ffd700'
     });
     header.setOrigin(0.5);
@@ -657,9 +661,9 @@ export class UIScene extends Phaser.Scene {
 
     // Category label
     const categoryNames = { mask: 'MASK CLUE', location: 'LOCATION CLUE', behavior: 'BEHAVIOR CLUE' };
-    const category = this.add.text(0, -25, categoryNames[clue.category as keyof typeof categoryNames], {
+    const category = this.add.text(0, -modalHeight/2 + 55, categoryNames[clue.category as keyof typeof categoryNames], {
       fontFamily: 'monospace',
-      fontSize: '12px',
+      fontSize: mobile ? '14px' : '12px',
       color: '#888888'
     });
     category.setOrigin(0.5);
@@ -668,21 +672,31 @@ export class UIScene extends Phaser.Scene {
     // Clue description
     const description = this.add.text(0, 10, clue.description, {
       fontFamily: 'monospace',
-      fontSize: '16px',
+      fontSize: mobile ? '18px' : '16px',
       color: '#ffffff',
       align: 'center',
-      wordWrap: { width: 320 }
+      wordWrap: { width: modalWidth - 40 }
     });
     description.setOrigin(0.5);
     modal.add(description);
 
-    // Continue prompt
-    const isMobile = isTouchDevice();
-    const promptText = isMobile ? '[Tap to continue]' : '[Press SPACE to continue]';
-    const prompt = this.add.text(0, 55, promptText, {
+    // Continue prompt - make it a button on mobile
+    const promptText = mobile ? '[ TAP TO CONTINUE ]' : '[Press SPACE to continue]';
+
+    if (mobile) {
+      const btnBg = this.add.graphics();
+      btnBg.fillStyle(0x8b0000, 0.8);
+      btnBg.fillRoundedRect(-100, modalHeight/2 - 50, 200, 40, 8);
+      btnBg.lineStyle(2, 0xffd700);
+      btnBg.strokeRoundedRect(-100, modalHeight/2 - 50, 200, 40, 8);
+      modal.add(btnBg);
+    }
+
+    const prompt = this.add.text(0, mobile ? modalHeight/2 - 30 : modalHeight/2 - 25, promptText, {
       fontFamily: 'monospace',
-      fontSize: '12px',
-      color: '#888888'
+      fontSize: mobile ? '16px' : '12px',
+      color: mobile ? '#ffd700' : '#888888',
+      fontStyle: mobile ? 'bold' : 'normal'
     });
     prompt.setOrigin(0.5);
     prompt.setInteractive({ useHandCursor: true });

--- a/src/scenes/UIScene.ts
+++ b/src/scenes/UIScene.ts
@@ -369,13 +369,20 @@ export class UIScene extends Phaser.Scene {
   private createInventoryPanel(): void {
     this.inventoryPanel = this.add.container(GAME_WIDTH / 2, GAME_HEIGHT / 2);
 
-    // Background
+    // Background - make it interactive for tap-to-close
     const bg = this.add.graphics();
     bg.fillStyle(0x1a1a2e, 0.95);
     bg.fillRect(-200, -150, 400, 300);
     bg.lineStyle(2, 0xffd700);
     bg.strokeRect(-200, -150, 400, 300);
     this.inventoryPanel.add(bg);
+
+    // Invisible hit area for tap-to-close
+    const hitArea = this.add.rectangle(0, 0, 400, 300);
+    hitArea.setInteractive({ useHandCursor: true });
+    hitArea.setAlpha(0.001);
+    hitArea.on('pointerdown', () => this.toggleInventory());
+    this.inventoryPanel.add(hitArea);
 
     // Title
     const title = this.add.text(0, -130, 'CLUE JOURNAL', {
@@ -386,8 +393,9 @@ export class UIScene extends Phaser.Scene {
     title.setOrigin(0.5);
     this.inventoryPanel.add(title);
 
-    // Close hint
-    const closeHint = this.add.text(0, 130, 'Press TAB to close', {
+    // Close hint - show tap hint on mobile
+    const mobile = isTouchDevice();
+    const closeHint = this.add.text(0, 130, mobile ? 'Tap to close' : 'Press TAB to close', {
       fontFamily: 'monospace',
       fontSize: '12px',
       color: '#888888'

--- a/src/scenes/UIScene.ts
+++ b/src/scenes/UIScene.ts
@@ -3,6 +3,13 @@ import { GameScene } from './GameScene';
 import { GAME_WIDTH, GAME_HEIGHT, SUSPICION_MAX } from '../config/GameConfig';
 import { ClueType } from '../types';
 
+// Helper to detect touch device
+const isTouchDevice = (): boolean => {
+  return 'ontouchstart' in window ||
+         navigator.maxTouchPoints > 0 ||
+         window.matchMedia('(pointer: coarse)').matches;
+};
+
 export class UIScene extends Phaser.Scene {
   private gameScene!: GameScene;
   private suspicionBar!: Phaser.GameObjects.Graphics;
@@ -471,9 +478,11 @@ export class UIScene extends Phaser.Scene {
   private updateInteractPrompt(): void {
     // Check for nearby interactive objects
     const nearbyNPC = this.gameScene['getNearbyNPC']?.();
+    const isTouch = isTouchDevice();
 
     if (nearbyNPC && nearbyNPC.isAlive) {
-      this.interactPrompt.setText('[E] Talk  [Q] Attack');
+      // On touch devices, buttons are visible, so just indicate what's possible
+      this.interactPrompt.setText(isTouch ? 'Tap E to Talk, Q to Attack' : '[E] Talk  [Q] Attack');
       this.interactPrompt.setAlpha(1);
     } else {
       // Check for doors
@@ -493,7 +502,7 @@ export class UIScene extends Phaser.Scene {
       }
 
       if (nearDoor) {
-        this.interactPrompt.setText('[E] Enter');
+        this.interactPrompt.setText(isTouch ? 'Tap E to Enter' : '[E] Enter');
         this.interactPrompt.setAlpha(1);
       } else {
         this.interactPrompt.setAlpha(0);

--- a/src/scenes/UIScene.ts
+++ b/src/scenes/UIScene.ts
@@ -677,12 +677,15 @@ export class UIScene extends Phaser.Scene {
     modal.add(description);
 
     // Continue prompt
-    const prompt = this.add.text(0, 55, '[Press SPACE to continue]', {
+    const isMobile = isTouchDevice();
+    const promptText = isMobile ? '[Tap to continue]' : '[Press SPACE to continue]';
+    const prompt = this.add.text(0, 55, promptText, {
       fontFamily: 'monospace',
       fontSize: '12px',
       color: '#888888'
     });
     prompt.setOrigin(0.5);
+    prompt.setInteractive({ useHandCursor: true });
     modal.add(prompt);
 
     // Pulse the prompt
@@ -694,18 +697,26 @@ export class UIScene extends Phaser.Scene {
       repeat: -1
     });
 
-    // Wait for key press to dismiss
+    // Wait for key press or tap to dismiss
     const dismissModal = () => {
       overlay.destroy();
       modal.destroy();
       this.input.keyboard?.off('keydown-SPACE', dismissModal);
       this.input.keyboard?.off('keydown-ENTER', dismissModal);
       this.input.keyboard?.off('keydown-E', dismissModal);
+      prompt.off('pointerdown', dismissModal);
+      overlay.off('pointerdown', dismissModal);
     };
 
+    // Keyboard
     this.input.keyboard?.once('keydown-SPACE', dismissModal);
     this.input.keyboard?.once('keydown-ENTER', dismissModal);
     this.input.keyboard?.once('keydown-E', dismissModal);
+
+    // Touch - tap anywhere on overlay or prompt
+    prompt.on('pointerdown', dismissModal);
+    overlay.setInteractive(new Phaser.Geom.Rectangle(0, 0, GAME_WIDTH, GAME_HEIGHT), Phaser.Geom.Rectangle.Contains);
+    overlay.on('pointerdown', dismissModal);
   }
 
   private onTargetIdentified(): void {

--- a/src/scenes/UIScene.ts
+++ b/src/scenes/UIScene.ts
@@ -109,7 +109,8 @@ export class UIScene extends Phaser.Scene {
   }
 
   private createGrandfatherClock(): void {
-    const clockX = GAME_WIDTH - 70;
+    // Clock positioned more to the left to make room for action buttons on both sides
+    const clockX = GAME_WIDTH - 170;
     const clockY = GAME_HEIGHT - 140;
 
     this.clockContainer = this.add.container(clockX, clockY);

--- a/src/systems/TouchControls.ts
+++ b/src/systems/TouchControls.ts
@@ -1,0 +1,342 @@
+import Phaser from 'phaser';
+
+export interface TouchInputState {
+  velocityX: number;
+  velocityY: number;
+  isSneaking: boolean;
+}
+
+export class TouchControls {
+  private scene: Phaser.Scene;
+  private joystickBase!: Phaser.GameObjects.Graphics;
+  private joystickThumb!: Phaser.GameObjects.Graphics;
+  private joystickPointer: Phaser.Input.Pointer | null = null;
+
+  private baseX = 0;
+  private baseY = 0;
+  private thumbX = 0;
+  private thumbY = 0;
+  private joystickRadius = 50;
+  private thumbRadius = 25;
+
+  public velocityX = 0;
+  public velocityY = 0;
+  public isActive = false;
+
+  // Action buttons
+  private interactButton!: Phaser.GameObjects.Container;
+  private attackButton!: Phaser.GameObjects.Container;
+  private inventoryButton!: Phaser.GameObjects.Container;
+  private sneakButton!: Phaser.GameObjects.Container;
+
+  public onInteract: (() => void) | null = null;
+  public onAttack: (() => void) | null = null;
+  public onInventory: (() => void) | null = null;
+  public isSneaking = false;
+
+  constructor(scene: Phaser.Scene) {
+    this.scene = scene;
+
+    // Only create touch controls on touch-capable devices
+    if (this.isTouchDevice()) {
+      this.createJoystick();
+      this.createActionButtons();
+      this.setupTouchListeners();
+      this.isActive = true;
+    }
+  }
+
+  private isTouchDevice(): boolean {
+    return 'ontouchstart' in window ||
+           navigator.maxTouchPoints > 0 ||
+           window.matchMedia('(pointer: coarse)').matches;
+  }
+
+  private createJoystick(): void {
+    const screenHeight = this.scene.cameras.main.height;
+
+    // Position joystick in bottom-left corner
+    this.baseX = 100;
+    this.baseY = screenHeight - 120;
+    this.thumbX = this.baseX;
+    this.thumbY = this.baseY;
+
+    // Create joystick base
+    this.joystickBase = this.scene.add.graphics();
+    this.joystickBase.fillStyle(0x000000, 0.4);
+    this.joystickBase.fillCircle(this.baseX, this.baseY, this.joystickRadius);
+    this.joystickBase.lineStyle(3, 0xffffff, 0.5);
+    this.joystickBase.strokeCircle(this.baseX, this.baseY, this.joystickRadius);
+    this.joystickBase.setDepth(1000);
+    this.joystickBase.setScrollFactor(0);
+
+    // Create joystick thumb
+    this.joystickThumb = this.scene.add.graphics();
+    this.drawThumb();
+    this.joystickThumb.setDepth(1001);
+    this.joystickThumb.setScrollFactor(0);
+  }
+
+  private drawThumb(): void {
+    this.joystickThumb.clear();
+    this.joystickThumb.fillStyle(0xffffff, 0.7);
+    this.joystickThumb.fillCircle(this.thumbX, this.thumbY, this.thumbRadius);
+    this.joystickThumb.lineStyle(2, 0xffd700, 0.8);
+    this.joystickThumb.strokeCircle(this.thumbX, this.thumbY, this.thumbRadius);
+  }
+
+  private createActionButtons(): void {
+    const screenWidth = this.scene.cameras.main.width;
+    const screenHeight = this.scene.cameras.main.height;
+
+    const buttonSize = 55;
+    const buttonPadding = 15;
+    const rightMargin = 30;
+    const bottomMargin = 100;
+
+    // Position buttons in bottom-right corner
+    const buttonBaseX = screenWidth - rightMargin - buttonSize;
+    const buttonBaseY = screenHeight - bottomMargin;
+
+    // Interact button (E) - primary action, large and prominent
+    this.interactButton = this.createButton(
+      buttonBaseX - buttonSize - buttonPadding,
+      buttonBaseY - buttonSize - buttonPadding,
+      buttonSize,
+      'E',
+      0x44aa44,
+      () => this.onInteract?.()
+    );
+
+    // Attack button (Q) - secondary action
+    this.attackButton = this.createButton(
+      buttonBaseX,
+      buttonBaseY - buttonSize - buttonPadding,
+      buttonSize,
+      'Q',
+      0xaa4444,
+      () => this.onAttack?.()
+    );
+
+    // Inventory button (Tab) - smaller, top right
+    this.inventoryButton = this.createButton(
+      buttonBaseX,
+      buttonBaseY - (buttonSize + buttonPadding) * 2,
+      buttonSize * 0.8,
+      'INV',
+      0x4444aa,
+      () => this.onInventory?.()
+    );
+
+    // Sneak button (Shift) - toggle
+    this.sneakButton = this.createButton(
+      buttonBaseX - buttonSize - buttonPadding,
+      buttonBaseY,
+      buttonSize * 0.9,
+      'SNEAK',
+      0x666666,
+      () => this.toggleSneak(),
+      true // is toggle
+    );
+  }
+
+  private createButton(
+    x: number,
+    y: number,
+    size: number,
+    label: string,
+    color: number,
+    callback: () => void,
+    isToggle = false
+  ): Phaser.GameObjects.Container {
+    const container = this.scene.add.container(x, y);
+    container.setDepth(1000);
+    container.setScrollFactor(0);
+
+    // Button background
+    const bg = this.scene.add.graphics();
+    bg.fillStyle(0x000000, 0.5);
+    bg.fillRoundedRect(0, 0, size, size, 10);
+    bg.lineStyle(3, color, 0.8);
+    bg.strokeRoundedRect(0, 0, size, size, 10);
+    container.add(bg);
+
+    // Button label
+    const fontSize = label.length > 2 ? '12px' : '18px';
+    const text = this.scene.add.text(size / 2, size / 2, label, {
+      fontFamily: 'monospace',
+      fontSize: fontSize,
+      color: '#ffffff',
+      fontStyle: 'bold'
+    });
+    text.setOrigin(0.5);
+    container.add(text);
+
+    // Make button interactive
+    const hitArea = this.scene.add.rectangle(size / 2, size / 2, size, size);
+    hitArea.setInteractive();
+    container.add(hitArea);
+    hitArea.setAlpha(0.001);
+
+    // Store reference for toggle buttons
+    container.setData('bg', bg);
+    container.setData('color', color);
+    container.setData('isToggle', isToggle);
+    container.setData('isActive', false);
+
+    // Touch events
+    hitArea.on('pointerdown', () => {
+      bg.clear();
+      bg.fillStyle(color, 0.7);
+      bg.fillRoundedRect(0, 0, size, size, 10);
+      bg.lineStyle(3, 0xffffff, 1);
+      bg.strokeRoundedRect(0, 0, size, size, 10);
+
+      callback();
+    });
+
+    hitArea.on('pointerup', () => {
+      if (!isToggle || !container.getData('isActive')) {
+        bg.clear();
+        bg.fillStyle(0x000000, 0.5);
+        bg.fillRoundedRect(0, 0, size, size, 10);
+        bg.lineStyle(3, color, 0.8);
+        bg.strokeRoundedRect(0, 0, size, size, 10);
+      }
+    });
+
+    hitArea.on('pointerout', () => {
+      if (!isToggle || !container.getData('isActive')) {
+        bg.clear();
+        bg.fillStyle(0x000000, 0.5);
+        bg.fillRoundedRect(0, 0, size, size, 10);
+        bg.lineStyle(3, color, 0.8);
+        bg.strokeRoundedRect(0, 0, size, size, 10);
+      }
+    });
+
+    return container;
+  }
+
+  private toggleSneak(): void {
+    this.isSneaking = !this.isSneaking;
+
+    const bg = this.sneakButton.getData('bg') as Phaser.GameObjects.Graphics;
+    const color = this.sneakButton.getData('color') as number;
+    const size = 55 * 0.9;
+
+    this.sneakButton.setData('isActive', this.isSneaking);
+
+    bg.clear();
+    if (this.isSneaking) {
+      bg.fillStyle(color, 0.8);
+      bg.fillRoundedRect(0, 0, size, size, 10);
+      bg.lineStyle(3, 0xffd700, 1);
+      bg.strokeRoundedRect(0, 0, size, size, 10);
+    } else {
+      bg.fillStyle(0x000000, 0.5);
+      bg.fillRoundedRect(0, 0, size, size, 10);
+      bg.lineStyle(3, color, 0.8);
+      bg.strokeRoundedRect(0, 0, size, size, 10);
+    }
+  }
+
+  private setupTouchListeners(): void {
+    // Handle joystick touch
+    this.scene.input.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+      // Check if touch is in the left half of the screen (joystick area)
+      if (pointer.x < this.scene.cameras.main.width / 2) {
+        this.joystickPointer = pointer;
+        this.updateJoystickPosition(pointer);
+      }
+    });
+
+    this.scene.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
+      if (this.joystickPointer && pointer.id === this.joystickPointer.id) {
+        this.updateJoystickPosition(pointer);
+      }
+    });
+
+    this.scene.input.on('pointerup', (pointer: Phaser.Input.Pointer) => {
+      if (this.joystickPointer && pointer.id === this.joystickPointer.id) {
+        this.resetJoystick();
+      }
+    });
+  }
+
+  private updateJoystickPosition(pointer: Phaser.Input.Pointer): void {
+    // Calculate distance from joystick base
+    const dx = pointer.x - this.baseX;
+    const dy = pointer.y - this.baseY;
+    const distance = Math.sqrt(dx * dx + dy * dy);
+
+    // Limit thumb to joystick radius
+    if (distance <= this.joystickRadius) {
+      this.thumbX = pointer.x;
+      this.thumbY = pointer.y;
+    } else {
+      const angle = Math.atan2(dy, dx);
+      this.thumbX = this.baseX + Math.cos(angle) * this.joystickRadius;
+      this.thumbY = this.baseY + Math.sin(angle) * this.joystickRadius;
+    }
+
+    // Calculate normalized velocity (-1 to 1)
+    this.velocityX = (this.thumbX - this.baseX) / this.joystickRadius;
+    this.velocityY = (this.thumbY - this.baseY) / this.joystickRadius;
+
+    // Apply dead zone
+    const deadZone = 0.15;
+    if (Math.abs(this.velocityX) < deadZone) this.velocityX = 0;
+    if (Math.abs(this.velocityY) < deadZone) this.velocityY = 0;
+
+    this.drawThumb();
+  }
+
+  private resetJoystick(): void {
+    this.joystickPointer = null;
+    this.thumbX = this.baseX;
+    this.thumbY = this.baseY;
+    this.velocityX = 0;
+    this.velocityY = 0;
+    this.drawThumb();
+  }
+
+  getInputState(): TouchInputState {
+    return {
+      velocityX: this.velocityX,
+      velocityY: this.velocityY,
+      isSneaking: this.isSneaking
+    };
+  }
+
+  show(): void {
+    if (!this.isActive) return;
+
+    this.joystickBase?.setVisible(true);
+    this.joystickThumb?.setVisible(true);
+    this.interactButton?.setVisible(true);
+    this.attackButton?.setVisible(true);
+    this.inventoryButton?.setVisible(true);
+    this.sneakButton?.setVisible(true);
+  }
+
+  hide(): void {
+    if (!this.isActive) return;
+
+    this.joystickBase?.setVisible(false);
+    this.joystickThumb?.setVisible(false);
+    this.interactButton?.setVisible(false);
+    this.attackButton?.setVisible(false);
+    this.inventoryButton?.setVisible(false);
+    this.sneakButton?.setVisible(false);
+  }
+
+  destroy(): void {
+    this.joystickBase?.destroy();
+    this.joystickThumb?.destroy();
+    this.interactButton?.destroy();
+    this.attackButton?.destroy();
+    this.inventoryButton?.destroy();
+    this.sneakButton?.destroy();
+  }
+}

--- a/src/systems/TouchControls.ts
+++ b/src/systems/TouchControls.ts
@@ -91,49 +91,54 @@ export class TouchControls {
     const gameHeight = GAME_HEIGHT;
 
     const buttonSize = 50;
-    const buttonPadding = 10;
-    const rightMargin = 20;
-    const bottomMargin = 70;
 
-    // Position buttons in bottom-right corner
-    const buttonBaseX = gameWidth - rightMargin - buttonSize;
-    const buttonBaseY = gameHeight - bottomMargin;
+    // Clock is at x = GAME_WIDTH - 170 (630 for 800px width)
+    // Clock body is ~70px wide, centered on that position
+    const clockCenterX = gameWidth - 170;
 
-    // Interact button (E) - primary action
+    // Right column (E on top, Q below) - to the RIGHT of the clock
+    const rightColumnX = clockCenterX + 70; // Right of clock body
+    const buttonTopY = gameHeight - 145;    // Upper button row
+    const buttonBottomY = gameHeight - 85;  // Lower button row
+
+    // Left column (INV on top, SNK below) - to the LEFT of the clock
+    const leftColumnX = clockCenterX - 70 - buttonSize; // Left of clock body
+
+    // Interact button (E) - top right of clock
     this.interactButton = this.createButton(
-      buttonBaseX - buttonSize - buttonPadding,
-      buttonBaseY - buttonSize - buttonPadding,
+      rightColumnX,
+      buttonTopY,
       buttonSize,
       'E',
       0x44aa44,
       () => this.onInteract?.()
     );
 
-    // Attack button (Q) - secondary action
+    // Attack button (Q) - bottom right of clock
     this.attackButton = this.createButton(
-      buttonBaseX,
-      buttonBaseY - buttonSize - buttonPadding,
+      rightColumnX,
+      buttonBottomY,
       buttonSize,
       'Q',
       0xaa4444,
       () => this.onAttack?.()
     );
 
-    // Inventory button (Tab) - smaller
+    // Inventory button (INV) - top left of clock
     this.inventoryButton = this.createButton(
-      buttonBaseX,
-      buttonBaseY - (buttonSize + buttonPadding) * 2,
-      buttonSize * 0.8,
+      leftColumnX,
+      buttonTopY,
+      buttonSize,
       'INV',
       0x4444aa,
       () => this.onInventory?.()
     );
 
-    // Sneak button (Shift) - toggle
+    // Sneak button (SNK) - bottom left of clock, toggle
     this.sneakButton = this.createButton(
-      buttonBaseX - buttonSize - buttonPadding,
-      buttonBaseY,
-      buttonSize * 0.85,
+      leftColumnX,
+      buttonBottomY,
+      buttonSize,
       'SNK',
       0x666666,
       () => this.toggleSneak(),


### PR DESCRIPTION
## Summary
- Add virtual joystick for movement on touch devices
- Add touch buttons for E (interact), Q (attack), INV (inventory), SNEAK (toggle)
- Auto-detect touch devices and only show controls on mobile
- Hide touch controls during dialogue

## Test plan
- [ ] Test on mobile device or browser dev tools mobile emulation
- [ ] Verify joystick controls movement
- [ ] Verify action buttons trigger correct actions
- [ ] Verify sneak toggle works
- [ ] Verify controls hide during dialogue

🤖 Generated with [Claude Code](https://claude.com/claude-code)